### PR TITLE
[Feature]  Add drag-and-drop functionality for reordering lists

### DIFF
--- a/src/components/DragAndDrop/DragAndDropContainer.tsx
+++ b/src/components/DragAndDrop/DragAndDropContainer.tsx
@@ -1,0 +1,44 @@
+import { useDragAndDropZone } from "@/utils/helpers/hooks/useDragAndDropZone";
+import { BoardType } from "@/utils/types/boards.types";
+import { ListType } from "@/utils/types/lists.types";
+import { DndContext, DragOverlay, MouseSensor, useSensor, useSensors } from "@dnd-kit/core";
+import { PropsWithChildren } from "react";
+import { DragOverlayTask } from "./DragOverlayTask";
+import { DragOverlayList } from "./DragOverlayList";
+import { TaskType } from "@/utils/types/tasks.types";
+
+/**
+ * A container for managing drag-and-drop functionality for tasks and lists within a board.
+ * Utilizes the `@dnd-kit` library to handle drag-and-drop interactions.
+ *
+ * @param {ListType[]} props.lists - An array of lists associated with the board.
+ * @param {BoardType} props.board - The board object containing metadata and associated lists.
+ * @param {React.ReactNode} props.children - The children components rendered inside the drag-and-drop context.
+ *
+ */
+export const DragAndDropContainer = ({ lists, board, children }: PropsWithChildren<{ lists: ListType[]; board: BoardType }>) => {
+  const { handleDragOver, handleDragEnd, handleDragStart, activeItem } = useDragAndDropZone(lists, board);
+
+  // Configure the MouseSensor with a constraint for activation
+  const mouseSensor = useSensor(MouseSensor, {
+    activationConstraint: {
+      distance: 10,
+    },
+  });
+
+  const sensors = useSensors(mouseSensor);
+
+  return (
+    <DndContext sensors={sensors} onDragOver={handleDragOver} onDragEnd={handleDragEnd} onDragStart={handleDragStart}>
+      {children}
+      <DragOverlay>
+        {activeItem &&
+          (activeItem.type === "task" ? (
+            <DragOverlayTask task={activeItem.item as TaskType} />
+          ) : activeItem.type === "list" ? (
+            <DragOverlayList list={activeItem.item as ListType} />
+          ) : null)}{" "}
+      </DragOverlay>
+    </DndContext>
+  );
+};

--- a/src/components/DragAndDrop/DragOverlayList.tsx
+++ b/src/components/DragAndDrop/DragOverlayList.tsx
@@ -1,0 +1,32 @@
+import { ListType } from "@/utils/types/lists.types";
+import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
+import { Trash } from "lucide-react";
+
+/**
+ * A visual representation of a draggable list overlay for use during drag-and-drop interactions.
+ * This component is rendered as a "ghost" overlay while a list is being dragged.
+ *
+ * @param {ListType} props.list - The list object containing the list title and tasks to display.
+ *
+ */
+export const DragOverlayList = ({ list }: { list: ListType }) => {
+  return (
+    <Card className="w-fit md:min-w-96 min-w-72 mb-2 rounded-xl animate-top-to-bottom opacity-30">
+      <section className="md:min-w-96 w-fit min-w-72 p-3 rounded-xl bg-gray-50 space-y-3 dark:bg-gray-900">
+        <CardHeader className="space-y-3">
+          <div className="flex justify-between items-center">
+            <CardTitle>{list.title}</CardTitle>
+            <span className="rounded-xl flex gap-2 shadow-none hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-600">
+              <Trash size={16} />
+            </span>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {Array.from({ length: list.tasks.length }).map((_, index) => (
+            <Card key={index} className="w-full h-32 bg-gray-300"></Card>
+          ))}
+        </CardContent>
+      </section>
+    </Card>
+  );
+};

--- a/src/components/DragAndDrop/DragOverlayTask.tsx
+++ b/src/components/DragAndDrop/DragOverlayTask.tsx
@@ -1,0 +1,49 @@
+import { TaskType } from "@/utils/types/tasks.types";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "../ui/card";
+import { TaskLabel } from "../Task/Label/TaskLabel";
+import { TaskDeadline } from "../Task/Deadline/TaskDeadline";
+import { TaskCheckListSection } from "../Task/CheckList/TaskCheckListSection";
+import { MessageSquare } from "lucide-react";
+import { MembersAvatarList } from "../Members/MembersAvatarList";
+import { Member } from "../Members/Member";
+import { Label } from "../Label/Label";
+
+/**
+ * A visual representation of a draggable task overlay for use during drag-and-drop interactions.
+ * This component is displayed as an animated "ghost" of the task while it is being dragged.
+ *
+ * @param {TaskType} props.task - The task object containing details like title, description, labels, and members.
+ *
+ */
+export const DragOverlayTask = ({ task }: { task: TaskType }) => {
+  return (
+    <Card className="border-none rounded-xl dark:bg-gray-800 dark:text-gray-300 animate-top-to-bottom opacity-90 shadow-xl transform scale-105 transition-all duration-300 ease-in-out">
+      <CardHeader>
+        <CardTitle className="text-lg font-semibold">{task.title}</CardTitle>
+        <section className="flex items-center gap-1 flex-wrap">
+          {task.labels && task.labels.length > 0 && task.labels.map((label, index) => <TaskLabel key={index} label={label} labels={task.labels} />)}
+        </section>
+      </CardHeader>
+      <CardContent>{task.description && <p className="text-xs text-gray-400 w-full line-clamp-3">{task.description}</p>}</CardContent>
+      <CardFooter className="flex gap-2 items-center justify-between">
+        {task.dueDate && <TaskDeadline dueDate={task.dueDate} taskId={task.id} isCard />}
+        <TaskCheckListSection taskId={task.id} isCard={true} />
+        {task.comments && task.comments.length > 0 && (
+          <Label color="#d1d5db">
+            <MessageSquare size={14} />
+            {task.comments.length}
+          </Label>
+        )}
+        {task.members && task.members.length > 0 && (
+          <div className="flex-1">
+            <MembersAvatarList members={task.members}>
+              {task.members.slice(0, 5).map((member) => (
+                <Member key={member} userId={member} type="avatar" />
+              ))}
+            </MembersAvatarList>
+          </div>
+        )}
+      </CardFooter>
+    </Card>
+  );
+};

--- a/src/components/DragAndDrop/DraggableContainer.tsx
+++ b/src/components/DragAndDrop/DraggableContainer.tsx
@@ -1,0 +1,41 @@
+import { PropsWithChildren } from "react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+
+/**
+ * A draggable container component for use with the `@dnd-kit` library.
+ * This component wraps its children and makes them draggable, supporting reordering
+ * and drag-and-drop interactions.
+ *
+ * @param {string} props.id - The unique identifier for the draggable container.
+ * @param {"list" | "task"} props.type - The type of the draggable container, indicating whether it represents a "list" or "task".
+ * @param {React.ReactNode} props.children - The child components to be rendered inside the draggable container.
+ *
+ */
+export const DraggableContainer = ({ id, type, children }: PropsWithChildren<{ id: string; type: "list" | "task" }>) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id,
+    data: {
+      type,
+    },
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      {...listeners}
+      {...attributes}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.3 : 1,
+        cursor: "grab",
+      }}
+      {...attributes}
+      {...listeners}
+      className={`${type === "list" ? "h-fit min-h-52" : ""}`}
+    >
+      {children}
+    </div>
+  );
+};

--- a/src/components/DragAndDrop/DroppableContainer.tsx
+++ b/src/components/DragAndDrop/DroppableContainer.tsx
@@ -1,0 +1,26 @@
+import { PropsWithChildren } from "react";
+import { useDroppable } from "@dnd-kit/core";
+
+/**
+ * A droppable container component for use with the `@dnd-kit` library.
+ * This component wraps its children and allows them to act as a drop target
+ * for drag-and-drop interactions.
+ * @param {string} props.id - The unique identifier for the droppable container.
+ * @param {"board" | "list"} props.type - The type of the droppable container, indicating whether it represents a "board" or "list".
+ * @param {React.ReactNode} props.children - The child components to be rendered inside the droppable container.
+ *
+ */
+export const DroppableContainer = ({ id, type, children }: PropsWithChildren<{ id: string; type: "board" | "list" }>) => {
+  const { setNodeRef } = useDroppable({
+    id,
+    data: {
+      type,
+    },
+  });
+
+  return (
+    <div ref={setNodeRef} className="h-fit">
+      {children}
+    </div>
+  );
+};

--- a/src/components/List/ListCard.tsx
+++ b/src/components/List/ListCard.tsx
@@ -1,7 +1,6 @@
 import { useMemo, useState } from "react";
 import { ListType } from "@/utils/types/lists.types";
 import { TaskType } from "../../utils/types/tasks.types";
-import { useDroppable } from "@dnd-kit/core";
 import { TaskCard } from "../Task/Card/TaskCard";
 import { useAddDoc } from "@/utils/hooks/FirestoreHooks/mutations/useAddDoc";
 import { useUpdateDoc } from "@/utils/hooks/FirestoreHooks/mutations/useUpdateDoc";
@@ -11,6 +10,8 @@ import { UpdateTitleForm } from "../Form/UpdateTitleForm";
 import { DeleteButton } from "../Button/DeleteButton";
 import { DeleteConfirmation } from "../Form/actions/DeleteConfirmation";
 import { AddForm } from "../Form/AddForm";
+import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { DroppableContainer } from "../DragAndDrop/DroppableContainer";
 
 /**
  * `ListCard` component renders a card that displays a list's title and tasks.
@@ -22,35 +23,18 @@ import { AddForm } from "../Form/AddForm";
  *
  * @returns The rendered ListCard component.
  */
-export const ListCard = ({
-  list,
-  boardId,
-}: {
-  list: ListType;
-  boardId: string;
-}) => {
+export const ListCard = ({ list, boardId }: { list: ListType; boardId: string }) => {
   const [isAddTask, setIsAddTask] = useState(false);
-  const { setNodeRef } = useDroppable({ id: list.id, data: { type: "list" } });
-
   /**
    * Memoized task cards, created from the list's task IDs.
    * This is used to optimize re-renders when the list changes.
    */
   const memoizedTasks = useMemo(() => {
-    return (
-      list &&
-      list.tasks.map((taskId) => (
-        <TaskCard key={taskId} taskId={taskId} list={list} />
-      ))
-    );
+    return list && list.tasks.map((taskId) => <TaskCard key={taskId} taskId={taskId} list={list} />);
   }, [list]);
 
   const createTask = useAddDoc<TaskType>(["tasks", list.id], "tasks");
-  const updateList = useUpdateDoc<Partial<ListType>>(
-    ["lists", boardId],
-    "lists",
-    list.id
-  );
+  const updateList = useUpdateDoc<Partial<ListType>>(["lists", boardId], "lists", list.id);
   const deleteList = useDeleteList<void>(boardId, list.id);
 
   /**
@@ -83,40 +67,27 @@ export const ListCard = ({
   };
 
   return (
-    <div ref={setNodeRef} className="w-fit md:min-w-96 min-w-72 mb-2 rounded-xl animate-top-to-bottom">
-      {list && (
-        <section className="md:min-w-96 w-fit min-w-72 p-3 rounded-xl bg-gray-50 space-y-3 dark:bg-gray-900">
-          <header className="space-y-3">
-            <div className="flex justify-between items-center">
-              <UpdateTitleForm
-                name="List"
-                title={list.title}
-                mutationQuery={updateList}
-                headingLevel={"h3"}
-              />
-              <DeleteButton>
-                {({ setIsOpen }) => (
-                  <DeleteConfirmation
-                    actionName="list"
-                    handleDelete={handleDeleteList}
-                    isPending={deleteList.isPending}
-                    setIsOpen={setIsOpen}
-                  />
-                )}
-              </DeleteButton>
-            </div>
-
-            <AddForm
-              name="Task"
-              onSubmit={handleCreateTask}
-              mutationQuery={createTask}
-              isOpen={isAddTask}
-              setIsOpen={setIsAddTask}
-            />
-          </header>
-          <section className="space-y-3">{memoizedTasks}</section>
-        </section>
-      )}
-    </div>
+    <SortableContext key={list.id} items={list.tasks} id={list.id} strategy={verticalListSortingStrategy}>
+      <DroppableContainer id={list.id} type="list">
+        <div className="w-fit md:min-w-96 min-w-72 mb-2 rounded-xl animate-top-to-bottom flex-shrink-0">
+          {list && (
+            <section className="md:min-w-96 w-fit min-w-72 p-3 rounded-xl bg-gray-50 space-y-3 dark:bg-gray-900">
+              <header className="space-y-3">
+                <div className="flex justify-between items-center">
+                  <UpdateTitleForm name="List" title={list.title} mutationQuery={updateList} headingLevel={"h3"} />
+                  <DeleteButton>
+                    {({ setIsOpen }) => (
+                      <DeleteConfirmation actionName="list" handleDelete={handleDeleteList} isPending={deleteList.isPending} setIsOpen={setIsOpen} />
+                    )}
+                  </DeleteButton>
+                </div>
+                <AddForm name="Task" onSubmit={handleCreateTask} mutationQuery={createTask} isOpen={isAddTask} setIsOpen={setIsAddTask} />
+              </header>
+              <section className="space-y-3">{memoizedTasks}</section>
+            </section>
+          )}
+        </div>
+      </DroppableContainer>
+    </SortableContext>
   );
 };

--- a/src/components/List/ListsSection.tsx
+++ b/src/components/List/ListsSection.tsx
@@ -1,25 +1,16 @@
 import { ListCard } from "@/components/List/ListCard";
-import {
-  DndContext,
-  DragOverlay,
-  closestCorners,
-  useSensors,
-  useSensor,
-  PointerSensor,
-} from "@dnd-kit/core";
-import {
-  SortableContext,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable";
 import { useState } from "react";
-import { Card } from "../ui/card";
 import { ListType } from "@/utils/types/lists.types";
-import { useDragMouse } from "@/utils/helpers/hooks/useDragMouse";
-import { useDragAndDropZone } from "../../utils/helpers/hooks/useDragAndDropZone";
 import { useGetLists } from "@/utils/hooks/FirestoreHooks/queries/useGetLists";
 import { useAddDoc } from "@/utils/hooks/FirestoreHooks/mutations/useAddDoc";
 import { AddForm } from "../Form/AddForm";
 import { FieldValues } from "react-hook-form";
+import { DragAndDropContainer } from "../DragAndDrop/DragAndDropContainer";
+import { horizontalListSortingStrategy, SortableContext } from "@dnd-kit/sortable";
+import { DraggableContainer } from "../DragAndDrop/DraggableContainer";
+import { useUpdateDoc } from "@/utils/hooks/FirestoreHooks/mutations/useUpdateDoc";
+import { BoardType } from "@/utils/types/boards.types";
+import { useDragMouse } from "@/utils/helpers/hooks/useDragMouse";
 
 /**
  * ListsSection component
@@ -27,35 +18,21 @@ import { FieldValues } from "react-hook-form";
  * This component renders a section containing a sortable, drag-and-drop enabled list of cards (representing lists).
  * It fetches the lists associated with a specific board, and allows creating new lists.
  *
- * @param   props - The props for the component.
- * @param {string} props.boardId - The ID of the board for which the lists are being displayed.
+ * @param {string} props.board - The board for which the lists are being displayed.
  *
  * @returns A JSX element containing a draggable list of cards, with the ability to add new lists.
  */
-export const ListsSection = ({ boardId }: { boardId: string }) => {
-  // Setup for drag-and-drop mouse interactions
+export const ListsSection = ({ board }: { board: BoardType }) => {
+  // Fetch the lists associated with the board
+  const { data: lists, isFetched } = useGetLists(board.id);
   const { sliderRef, handleMouseDown, handleMouseLeaveOrUp, handleMouseMove } = useDragMouse();
 
-  // Fetch the lists associated with the board
-  const { data: lists, isFetched } = useGetLists(boardId);
-
   // Mutation to create a new list
-  const createList = useAddDoc<ListType>(["lists", boardId], "lists");
+  const createList = useAddDoc<ListType>(["lists", board.id], "lists");
+  const updateBoard = useUpdateDoc<Partial<BoardType>>(["board", board.id], "boards", board.id);
 
   // State to control whether the "Add List" form is visible
   const [isAddList, setIsAddList] = useState(false);
-
-  // Drag-and-drop handlers
-  const { handleDragStart, handleDragOver, handleDragEnd, activeTask } = useDragAndDropZone({ lists, boardId });
-
-  // Setup sensors for the drag-and-drop context
-  const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: {
-        distance: 8,
-      },
-    })
-  );
 
   /**
    * Handles the creation of a new list.
@@ -68,69 +45,48 @@ export const ListsSection = ({ boardId }: { boardId: string }) => {
         title: data.title,
         createdAt: Date.now(),
         tasks: [],
-        boardId,
+        boardId: board.id,
       },
       {
-        onSuccess: () => {
+        onSuccess: (newListId) => {
+          updateBoard.mutate({
+            lists: [...board.lists, newListId],
+          });
           setIsAddList(false); // Close the "Add List" form upon success
         },
       }
     );
   };
 
-  if(!isFetched) {
+  if (!isFetched || !lists) {
     return null;
   }
 
-
   return (
-    <DndContext
-      onDragStart={handleDragStart}
-      onDragEnd={handleDragEnd}
-      onDragOver={handleDragOver}
-      collisionDetection={closestCorners}
-      sensors={sensors}
-    >
+    <DragAndDropContainer lists={lists} board={board}>
       <section
-        className="overflow-x-auto flex-1 flex flex-col w-full no-scrollbar mb-10"
+        className="overflow-x-auto flex flex-col w-full no-scrollbar mt-10"
         ref={sliderRef}
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}
         onMouseLeave={handleMouseLeaveOrUp}
         onMouseUp={handleMouseLeaveOrUp}
       >
-        <section className="flex items-start flex-nowrap mt-10 gap-5 flex-1">
-          {lists &&
-            lists
-              .sort((a, b) => a.createdAt - b.createdAt)
-              .map((list) => (
-                <SortableContext
-                  key={list.id}
-                  items={list.tasks}
-                  id={list.id}
-                  strategy={verticalListSortingStrategy}
-                >
-                  <ListCard list={list} boardId={boardId} />
-                </SortableContext>
-              ))}
-          <div className="min-w-72">
-            <AddForm
-              name="List"
-              onSubmit={handleCreateList}
-              mutationQuery={createList}
-              isOpen={isAddList}
-              setIsOpen={setIsAddList}
-            />
-          </div>
-        </section>
+        <SortableContext items={lists.map((list) => list.id)} strategy={horizontalListSortingStrategy}>
+            <section className="flex gap-5">
+              {lists
+                .sort((a, b) => board.lists.indexOf(a.id) - board.lists.indexOf(b.id))
+                .map((list) => (
+                  <DraggableContainer id={list.id} type="list" key={list.id}>
+                    <ListCard list={list} boardId={board.id} />
+                  </DraggableContainer>
+                ))}
+              <div className="min-w-72">
+                <AddForm name="List" onSubmit={handleCreateList} mutationQuery={createList} isOpen={isAddList} setIsOpen={setIsAddList} />
+              </div>
+            </section>
+        </SortableContext>
       </section>
-      <DragOverlay>
-        {activeTask ? (
-          <Card className="py-6 px-2 min-h-13 shadow-none border-none cursor-grabbing">
-            {activeTask.title}
-          </Card>
-        ) : null}
-      </DragOverlay>
-    </DndContext>
+    </DragAndDropContainer>
   );
 };

--- a/src/components/Task/Card/TaskCard.tsx
+++ b/src/components/Task/Card/TaskCard.tsx
@@ -7,8 +7,6 @@ import {
   CardHeader,
   CardTitle,
 } from "../../ui/card";
-import { useSortable } from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
 import { TaskType } from "@/utils/types/tasks.types";
 import { ListType } from "@/utils/types/lists.types";
 import { MessageSquare } from "lucide-react";
@@ -20,6 +18,7 @@ import { Label } from "@/components/Label/Label";
 import { MembersAvatarList } from "@/components/Members/MembersAvatarList";
 import { Member } from "@/components/Members/Member";
 import { TaskDetails } from "../TaskDetails/TaskDetails";
+import { DraggableContainer } from "@/components/DragAndDrop/DraggableContainer";
 
 /**
  * TaskCard component that displays a detailed task card with labels, description, checklist, members, and other task details.
@@ -40,24 +39,12 @@ export const TaskCard = ({
   const [isTaskOpen, setIsTaskOpen] = useState(false); // State to manage modal visibility
   const { data: task, isFetched } = useGetDoc<TaskType>("tasks", taskId); // Fetch task data
 
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging,
-  } = useSortable({
-    id: taskId,
-    data: { type: "task" },
-  });
-
   if (!isFetched) {
     return null;
   }
 
   return (
-    <div ref={setNodeRef}>
+    <DraggableContainer id={taskId} type="task">
       {task && (
         <>
           <Modal
@@ -65,17 +52,7 @@ export const TaskCard = ({
             setIsModalOpen={setIsTaskOpen}
             isModalOpen={isTaskOpen}
           >
-            <Card
-              className="border-none rounded-xl dark:bg-gray-800 dark:text-gray-300 animate-top-to-bottom"
-              style={{
-                transform: CSS.Transform.toString(transform),
-                transition,
-                opacity: isDragging ? 0.3 : 1,
-                cursor: "grab",
-              }}
-              {...attributes}
-              {...listeners}
-            >
+            <Card className="border-none rounded-xl dark:bg-gray-800 dark:text-gray-300 animate-top-to-bottom">
               {/* Task Header */}
               <CardHeader>
                 <CardTitle>{task.title}</CardTitle>
@@ -142,6 +119,6 @@ export const TaskCard = ({
           </Modal>
         </>
       )}
-    </div>
+    </DraggableContainer>
   );
 };

--- a/src/pages/BoardPage.tsx
+++ b/src/pages/BoardPage.tsx
@@ -97,7 +97,7 @@ export const BoardPage = () => {
             </div>
           </header>
           {/* Display lists associated with the board */}
-          <ListsSection boardId={boardId} />
+          <ListsSection board={board} />
         </>
       )}
     </main>

--- a/src/utils/helpers/hooks/useDragAndDropZone.tsx
+++ b/src/utils/helpers/hooks/useDragAndDropZone.tsx
@@ -1,204 +1,204 @@
-import { DragEndEvent, DragStartEvent, DragOverEvent } from "@dnd-kit/core";
-import { useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
-import { TaskType } from "@/utils/types/tasks.types";
 import { FirestoreService } from "@/utils/firebase/firestore/firestoreService";
+import { BoardType } from "@/utils/types/boards.types";
 import { ListType } from "@/utils/types/lists.types";
+import { TaskType } from "@/utils/types/tasks.types";
+import { DragEndEvent, DragOverEvent, DragStartEvent } from "@dnd-kit/core";
+import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
 
-type DragAndDropZoneProps = {
-  lists?: ListType[];
-  boardId: string;
-};
 
 /**
- * Custom hook to handle drag-and-drop events for tasks.
- * This hook provides:
- * - Tracking of the active task during dragging.
- * - Managing list changes when a task is moved between lists.
- * - Sorting tasks within the same list or between multiple lists.
- * 
- * The hook uses optimistic updates, updating the UI before synchronizing the changes with Firestore.
- * 
- * @param {DragAndDropZoneProps} props - Properties containing the list of tasks and the board ID.
- * @returns Handlers for drag start, drag over, and drag end events, as well as the active task state.
- */
-export const useDragAndDropZone = ({ lists, boardId }: DragAndDropZoneProps) => {
-  const [activeTask, setActiveTask] = useState<TaskType | null>(null);
+ * Custom hook to manage drag-and-drop functionality for tasks and lists.
+ *
+ * @param {ListType[]} lists - The lists associated with the current board.
+ * @param {BoardType} board - The current board containing the lists.
+ *
+*   handleDragStart: (event: DragStartEvent) => Promise<void>,
+*   handleDragOver: (event: DragOverEvent) => Promise<void>,
+*   handleDragEnd: (event: DragEndEvent) => Promise<void>,
+*   activeItem: { item: TaskType | ListType; type: "task" | "list" } | null
+*/
+export const useDragAndDropZone = (lists: ListType[], board: BoardType) => {
   const queryClient = useQueryClient();
 
-  /**
-   * Retrieves task data to display in the DragOverlay.
-   * 
-   * @param {string} taskId - ID of the task being dragged.
+    // State to track the currently active item being dragged.
+  const [activeItem, setActiveItem] = useState<{ item: TaskType | ListType; type: "task" | "list" } | null>(null);
+
+   /**
+   * Handles the start of a drag operation.
+   *
+   * @param {DragStartEvent} event - The event triggered when dragging starts.
    */
-  const getActiveTask = async (taskId: string) => {
-    const task = await new Promise<TaskType>((resolve, reject) => {
-      const unsubscribe = FirestoreService.subscribeToDocument<TaskType>(
-        "tasks",
-        taskId,
-        (task) => {
-          if (task) {
-            resolve(task);
-          } else {
-            reject(new Error(`Task with ID ${taskId} not found`));
-          }
-        },
-        (error) => {
-          reject(new Error(`Error while getting document: ${error.message}`));
-        },
-      );
-      return () => unsubscribe;
-    });
-    setActiveTask(task);
+  const handleDragStart = async ({ active }: DragStartEvent) => {
+    const activeType = active.data.current?.type;
+    console.log(active);
+
+    if (activeType === "task") {
+      const task = await FirestoreService.fetchDoc<TaskType>("tasks", active.id.toString());
+      if (!task) return;
+      setActiveItem({ item: task, type: "task" });
+    } else {
+      const list = await FirestoreService.fetchDoc<ListType>("lists", active.id.toString());
+      if (!list) return;
+      setActiveItem({ item: list, type: "list" });
+    }
   };
 
-  /**
-   * Sets the active task for dragging.
-   * 
-   * @param {DragStartEvent} active - The drag start event object.
-   */
-  const handleDragStart = ({ active }: DragStartEvent) => {
-    getActiveTask(active.id.toString());
-  };
 
-  /**
-   * Handles list changes when a task is dragged over a different list.
-   * 
-   * @param {DragOverEvent} active - The drag over event object.
+   /**
+   * Handles the drag-over event, updating the local React Query cache
+   * and preparing the data for persistence in Firestore.
+   *
+   * @param {DragOverEvent} event - The event triggered when dragging over a droppable area.
    */
   const handleDragOver = async ({ active, over }: DragOverEvent) => {
-    if (!over || !lists) {
-      return;
-    }
+    if (!over) return;
 
-    const initialContainer = active.data.current?.sortable?.containerId;
-    const targetContainer = over.data.current?.sortable?.containerId;
+    const activeType = active.data.current?.type;
+    const overType = over.data.current?.type;
 
-    const targetType = over.data.current?.type;
+    if (activeType === "task") {
+      const overListId = overType === "list" ? over.id : over.data.current?.sortable?.containerId;
+      const activeListId = active.data.current?.sortable?.containerId;
 
-    if (!initialContainer || initialContainer === targetContainer) {
-      return;
-    }
+      // Récupérer les listes concernées
+      const overList = lists.find((list) => list.id === overListId);
+      const activeList = lists.find((list) => list.id === activeListId);
 
-    const overId = targetContainer ? targetContainer : over.id.toString();
+      // Vérification de la validité des listes
+      if (!activeList || !overList) return;
 
-    const oldList = lists.find((list) => list.id === initialContainer);
-    const newList = lists.find((list) => list.id === overId);
+      // Indices des tâches
+      const overIndex = over.data.current?.sortable?.index ?? 0;
+      const activeIndex = active.data.current?.sortable?.index ?? null;
 
-    if (oldList && newList && !newList.tasks.includes(active.id.toString())) {
-      const targetIndex =
-        targetType === "task"
-          ? over.data.current?.sortable?.index
-          : newList.tasks.length === 0
-            ? 0
-            : newList.tasks.length - 1;
+      if (activeList === overList) {
+        if (overIndex === null || activeIndex === null) return;
 
-      const sortedTask = [...newList.tasks];
-      sortedTask.splice(targetIndex, 0, active.id.toString());
+        // Reorganize tasks within the same list.
+        const updatedTasks = [...activeList.tasks];
+        const [movedTask] = updatedTasks.splice(activeIndex, 1);
+        updatedTasks.splice(overIndex, 0, movedTask);
 
-      const removedTask = oldList.tasks.filter(
-        (taskId) => taskId !== active.id
-      );
+        queryClient.setQueryData(["lists", board.id], (previousLists?: ListType[]) => {
+          if (!previousLists) return previousLists;
+          return previousLists.map((list) => (list.id === activeList.id ? { ...list, tasks: updatedTasks } : list));
+        });
+      } else {
+        if (overIndex === null) return;
 
-      // Optimistic update
-      queryClient.setQueryData(
-        ["lists", boardId],
-        (oldLists: ListType[] | undefined) => {
-          if (!oldLists) return oldLists;
+         // Update tasks in both the active list and the target list.
+        const updatedActiveListTasks = activeList.tasks.filter((taskId) => taskId !== active.id);
 
-          return oldLists.map((list) => {
-            if (list.id === newList.id) {
-              return { ...list, tasks: sortedTask };
-            } else if (list.id === oldList.id) {
-              return { ...list, tasks: removedTask };
-            } else {
-              return list;
+        const updatedOverListTasks = [...overList.tasks];
+        updatedOverListTasks.splice(overIndex, 0, active.id.toString());
+
+        queryClient.setQueryData(["lists", board.id], (previousLists?: ListType[]) => {
+          if (!previousLists) return previousLists;
+          return previousLists.map((list) => {
+            if (list.id === activeList.id) {
+              return { ...list, tasks: updatedActiveListTasks };
             }
-          });
-        }
-      );
-
-      // Firestore update
-      try {
-        await Promise.all([
-          FirestoreService.updateDocument<ListType>(
-            "lists",
-            { tasks: sortedTask },
-            newList.id
-          ),
-          FirestoreService.updateDocument<ListType>(
-            "lists",
-            { tasks: removedTask },
-            oldList.id
-          ),
-        ]);
-        queryClient.invalidateQueries({ queryKey: ["lists", boardId] });
-      } catch (error: any) {
-        queryClient.invalidateQueries({ queryKey: ["lists", boardId] });
-        throw new Error(error);
-      }
-    }
-  };
-
-  /**
-   * Handles task sorting within the same list after dragging ends.
-   * 
-   * @param {DragEndEvent} active - The drag end event object.
-   */
-  const handleDragEnd = async ({ active, over }: DragEndEvent) => {
-    if (!over || !lists || !active.data.current || !over.data.current) {
-      setActiveTask(null);
-      return;
-    }
-
-    const initialContainer = active.data.current.sortable?.containerId;
-    const targetContainer = over.data.current?.sortable?.containerId;
-
-    if (active.id === over.id || initialContainer !== targetContainer) {
-      setActiveTask(null);
-      return;
-    }
-
-    setActiveTask(null);
-
-    const targetIndex = over.data.current?.sortable?.index;
-    const listToUpdate = lists.find((list) => list.id === initialContainer);
-
-    if (listToUpdate) {
-      const sortedTask = [
-        ...listToUpdate.tasks.filter((id) => id !== active.id),
-      ];
-      sortedTask.splice(targetIndex, 0, active.id.toString());
-
-      // Optimistic update
-      queryClient.setQueryData(
-        ["lists", boardId],
-        (oldLists: ListType[] | undefined) => {
-          if (!oldLists) return oldLists;
-
-          return oldLists.map((list) => {
-            if (list.id === listToUpdate.id) {
-              return { ...list, tasks: sortedTask };
+            if (list.id === overList.id) {
+              return { ...list, tasks: updatedOverListTasks };
             }
             return list;
           });
-        }
-      );
+        });
 
-      // Firestore update
+
+        // Persist the changes in Firestore.
+        try {
+            await Promise.all([
+              FirestoreService.updateDocument<ListType>("lists", { tasks: updatedOverListTasks }, overList.id),
+              FirestoreService.updateDocument<ListType>("lists", { tasks: updatedActiveListTasks }, activeList.id),
+            ]);
+          } catch (error: any) {
+            queryClient.invalidateQueries({ queryKey: ["lists", board.id] });
+            throw new Error(error);
+          }
+      }
+    }
+
+    // Sort when the lists move
+    if (activeType === "list" && overType !== "task") {
+      // Find indexs
+      const activeIndex = board.lists.indexOf(active.id.toString());
+      const overIndex = board.lists.indexOf(over.id.toString());
+
+      // Copy board lists to handle sort
+      const sortedListsInBoard = [...board.lists];
+
+      // Delete active elements from is
+      sortedListsInBoard.splice(activeIndex, 1);
+
+      // Insérer l'élément actif à la nouvelle position
+      sortedListsInBoard.splice(overIndex, 0, active.id.toString());
+
+      queryClient.setQueryData(["board", board.id], (previousBoard?: BoardType) => {
+        if (!previousBoard) return previousBoard;
+        return { ...board, lists: sortedListsInBoard };
+      });
+    }
+  };
+
+
+    /**
+   * Handles the end of a drag operation, finalizing updates in Firestore.
+   *
+   * @param {DragEndEvent} event - The event triggered when dragging ends.
+   */
+  const handleDragEnd = async ({ active, over }: DragEndEvent) => {
+    if (!over) return;
+    setActiveItem(null);
+
+    const activeType = active.data.current?.type;
+    const overType = over.data.current?.type;
+
+
+    // Update lists ordrer in the board
+    if (activeType === "list" && overType !== "task") {
+
+      // Get the new board in Local query cache set in the dragover fn
+      const newBoard: BoardType | undefined = queryClient.getQueryData(["board", board.id]);
       try {
-        await FirestoreService.updateDocument<ListType>(
-          "lists",
-          { tasks: sortedTask },
-          listToUpdate.id
-        );
-        queryClient.invalidateQueries({ queryKey: ["lists", boardId] });
-      } catch (error: any) {
-        queryClient.invalidateQueries({ queryKey: ["lists", boardId] });
-        throw new Error(error);
+        if (!newBoard) {
+          queryClient.invalidateQueries({ queryKey: ["board", board.id] });
+          return;
+        }
+        await FirestoreService.updateDocument<BoardType>("boards", { lists: newBoard.lists }, board.id);
+      } catch (error) {
+        queryClient.invalidateQueries({ queryKey: ["board", board.id] });
+        console.error(`Error while updating the board ${board.id}`);
+        throw error;
+      }
+    }
+
+
+    // Update the tasks order in lists
+    if (activeType === "task") {
+      const activeListId = active.data.current?.sortable?.containerId;
+
+      const newLists: ListType[] | undefined = queryClient.getQueryData(["lists", board.id]);
+      if (!newLists) {
+        queryClient.invalidateQueries({ queryKey: ["lists", board.id] });
+      }
+
+      // Get the new list in Local query cache set in the dragover fn
+      const activeList = newLists?.find((list) => list.id === activeListId.toString());
+      try {
+        if (!activeList) {
+          queryClient.invalidateQueries({ queryKey: ["lists", board.id] });
+          return;
+        }
+        await FirestoreService.updateDocument<ListType>("lists", { tasks: activeList.tasks }, activeList.id);
+      } catch (error) {
+        queryClient.invalidateQueries({ queryKey: ["lists", board.id] });
+        console.error(`Error while updating the list ${activeList?.id}`);
+        throw error;
       }
     }
   };
 
-  return { handleDragStart, handleDragOver, handleDragEnd, activeTask };
+  return { handleDragStart, handleDragOver, handleDragEnd, activeItem };
 };

--- a/src/utils/types/boards.types.ts
+++ b/src/utils/types/boards.types.ts
@@ -1,6 +1,7 @@
   export type BoardType = {
     id: string;
     title: string;
+    lists: string[];
     members: string[]; 
     creator: string;
     createdAt: number;


### PR DESCRIPTION
### Context
We added drag-and-drop functionality for tasks, allowing them to be moved between lists and sorted. This feature has now been extended to lists, enabling users to reorder their lists as well.

### Changes
- Modified the `board` object to include an array of list IDs, which manages the order of the lists.
- Updated board creation queries and any other queries that modify the list ID array to reflect the changes.
- Refactored the code by introducing new containers to manage drag-and-drop interactions:
  - `DragAndDropContainer`: Implements `DndContext` and handles drag start, over, and end events.
  - `DroppableContainer`: A container where items can be dropped.
  - `DraggableContainer`: Makes the children draggable.
  - `DragOverlayList` and `DragOverlayTag`: Display overlays while dragging.
  
- Improved the `useDragAndDropZone` hook by adding support for dragging and dropping lists and optimizing Firebase query management. 
  - Utilized `setQueryData` to update the UI before updating Firebase to ensure a smoother experience.

### Purpose
This feature allows users to reorder their lists within a board, enhancing the overall usability of the drag-and-drop functionality. The improvements also ensure better performance by optimizing how the app communicates with Firebase during list updates.
